### PR TITLE
Fix a float index bug

### DIFF
--- a/DictionaryGenerator.py
+++ b/DictionaryGenerator.py
@@ -100,7 +100,7 @@ def generateDictionary(alphabet, minSize, maxSize):
 					indexValue = math.floor((currentIndex / pow(alphabetSize, reversePosition)))  % alphabetSize
 
 					# Add the character of the alphabet to the word
-					word += alphabet[indexValue]
+					word += alphabet[int(indexValue)]
 
 				file.write(word + '\n')
 				


### PR DESCRIPTION
With Python 2.7.11 :

Traceback (most recent call last):
  File "DictionaryGenerator.py", line 165, in <module>
    generateDictionary(alphabet, minSize, maxSize)
  File "DictionaryGenerator.py", line 103, in generateDictionary
    word += alphabet[indexValue]
TypeError: string indices must be integers, not float
